### PR TITLE
Update nom to 8.0.0 and fix XML parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,9 +57,9 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.7"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,12 +134,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "miniz_oxide"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -187,12 +181,11 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "7.1.3"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
- "minimal-lexical",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ tokio = { version = "1.0", features = ["full"] }
 bytes = "1.0"
 thiserror = "2.0.11"
 tracing = "0.1.41"
-nom = "7.1"
+nom = "8.0.0"
 async-trait = "0.1.74"
 base64 = "0.21.7"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ thiserror = "2.0.11"
 tracing = "0.1.41"
 nom = "8.0.0"
 async-trait = "0.1.74"
-base64 = "0.21.7"
+base64 = "0.22.1"
 
 [dev-dependencies]
 mockall = { version = "0.13.1", features = [] }

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,50 +1,36 @@
 use base64::engine::general_purpose::STANDARD;
 use base64::Engine;
-use nom::{
-    bytes::complete::{tag, take_while1},
-    character::complete::{char, multispace0},
-    multi::many0,
-    sequence::delimited,
-    IResult,
-};
+use nom::bytes::complete::{tag, take_while1};
+use nom::character::complete::{char, multispace0};
+use nom::multi::many0;
+use nom::sequence::delimited;
+use nom::branch::alt;
+use nom::Parser;
+use nom::IResult;
 
 use crate::error::{Error, Result};
-use crate::property::PropertyValue;
+use crate::property::{PropertyPerm, PropertyState, PropertyValue};
 
-/// INDI protocol message types
 #[derive(Debug, Clone)]
-pub enum Message {
-    /// Define a device
-    DefDevice(String),
-    /// Define a property
-    DefProperty(String),
-    /// Set a property value
-    SetProperty(String),
-    /// Get a property value
-    GetProperty(String),
-    /// New property value
-    NewProperty(String),
-    /// Delete a property
-    DelProperty(String),
-    /// Message from device
-    Message(String),
-}
-
-#[derive(Debug)]
 struct XmlAttribute {
     name: String,
     value: String,
 }
 
-fn is_name_char(c: char) -> bool {
-    c.is_alphanumeric() || c == '_' || c == '-'
-}
-
 fn parse_attribute(input: &str) -> IResult<&str, XmlAttribute> {
-    let (input, _) = multispace0(input)?;
-    let (input, name) = take_while1(is_name_char)(input)?;
-    let (input, _) = tag("=")(input)?;
-    let (input, value) = delimited(char('"'), take_while1(|c| c != '"'), char('"'))(input)?;
+    // Skip leading whitespace
+    let (input, _) = multispace0.parse(input)?;
+
+    // Parse attribute name
+    let (input, name) = take_while1(|c: char| c.is_alphanumeric() || c == '_').parse(input)?;
+
+    // Skip whitespace and equals sign
+    let (input, _) = multispace0.parse(input)?;
+    let (input, _) = char('=').parse(input)?;
+    let (input, _) = multispace0.parse(input)?;
+
+    // Parse attribute value in quotes
+    let (input, value) = delimited(char('"'), take_while1(|c| c != '"'), char('"')).parse(input)?;
 
     Ok((
         input,
@@ -56,185 +42,123 @@ fn parse_attribute(input: &str) -> IResult<&str, XmlAttribute> {
 }
 
 fn parse_attributes(input: &str) -> IResult<&str, Vec<XmlAttribute>> {
-    many0(parse_attribute)(input)
+    many0(parse_attribute).parse(input)
 }
 
-fn parse_xml_tag(input: &str) -> IResult<&str, (String, Vec<XmlAttribute>, Option<String>)> {
-    let (input, _) = char('<')(input)?;
-    let (input, tag_name) = take_while1(is_name_char)(input)?;
+fn parse_element_start(input: &str) -> IResult<&str, (String, Vec<XmlAttribute>)> {
+    // Skip leading whitespace and opening angle bracket
+    let (input, _) = multispace0.parse(input)?;
+    let (input, _) = char('<').parse(input)?;
+
+    // Parse element name
+    let (input, name) = take_while1(|c: char| c.is_alphanumeric() || c == '_').parse(input)?;
+
+    // Parse attributes
     let (input, attrs) = parse_attributes(input)?;
-    let (input, _) = multispace0(input)?;
 
-    // Handle self-closing tags
-    let (input, content) = if input.starts_with("/>") {
-        let (input, _) = tag("/>")(input)?;
-        (input, None)
-    } else {
-        let (input, _) = char('>')(input)?;
-        let mut content = String::new();
-        let mut depth = 1;
-        let mut pos = 0;
+    // Skip closing angle bracket or self-closing tag
+    let (input, _) = multispace0.parse(input)?;
+    let (input, _) = alt((tag("/>"), tag(">"))).parse(input)?;
 
-        // Convert input to chars for easier indexing
-        let chars: Vec<char> = input.chars().collect();
+    Ok((input, (name.to_string(), attrs)))
+}
 
-        while pos < chars.len() {
-            let slice = &input[pos..];
-            let end_tag = format!("</{}", tag_name);
-            let start_tag = format!("<{}", tag_name);
+fn parse_element_content(input: &str) -> IResult<&str, String> {
+    // Parse content until closing angle bracket
+    let (input, content) = take_while1(|c| c != '<').parse(input)?;
 
-            if slice.starts_with(&end_tag) {
-                depth -= 1;
-                if depth == 0 {
-                    // Skip to end of tag
-                    while pos < chars.len() && chars[pos] != '>' {
-                        pos += 1;
-                    }
-                    pos += 1; // Skip '>'
-                    let remaining = &input[pos..];
-                    return Ok((remaining, (tag_name.to_string(), attrs, Some(content))));
-                }
-            } else if slice.starts_with(&start_tag) {
-                depth += 1;
-            }
+    Ok((input, content.to_string()))
+}
 
-            if pos < chars.len() {
-                content.push(chars[pos]);
-            }
-            pos += 1;
-        }
-
-        (input, Some(content))
-    };
-
-    Ok((input, (tag_name.to_string(), attrs, content)))
+/// Message types supported by the INDI protocol
+#[derive(Debug, Clone)]
+pub enum Message {
+    /// Get property definition
+    GetProperty(String),
+    /// Define property
+    DefProperty(String),
+    /// Set property
+    SetProperty(String),
+    /// New property
+    NewProperty(String),
+    /// Define a device
+    DefDevice(String),
+    /// Message from device
+    Message(String),
 }
 
 impl Message {
-    /// Parse an XML string into a Message
+    /// Parse XML message into Message enum
     pub fn from_xml(xml: &str) -> Result<Self> {
-        println!("Parsing XML: {}", xml);
-        let (_, (tag_name, attrs, content)) = parse_xml_tag(xml.trim())
-            .map_err(|e| Error::Message(format!("Failed to parse XML: {}", e)))?;
+        let (_, (name, _)) = parse_element_start(xml).map_err(|e| Error::Message(e.to_string()))?;
 
-        // Reconstruct the XML for storage
-        let mut xml_content = format!("<{}", tag_name);
-        for attr in &attrs {
-            xml_content.push_str(&format!(" {}=\"{}\"", attr.name, attr.value));
-        }
-
-        if let Some(content) = content {
-            println!("Found content: {}", content);
-            xml_content.push('>');
-            xml_content.push_str(&content);
-            xml_content.push_str("</");
-            xml_content.push_str(&tag_name);
-            xml_content.push('>');
-        } else {
-            println!("No content found");
-            xml_content.push_str("/>");
-        }
-
-        println!("Reconstructed XML: {}", xml_content);
-        match tag_name.as_str() {
-            "defDevice" => Ok(Message::DefDevice(xml_content)),
-            "defProperty" => Ok(Message::DefProperty(xml_content)),
-            "setProperty" => Ok(Message::SetProperty(xml_content)),
-            "getProperty" => Ok(Message::GetProperty(xml_content)),
-            "newProperty" => Ok(Message::NewProperty(xml_content)),
-            "delProperty" => Ok(Message::DelProperty(xml_content)),
-            "message" => Ok(Message::Message(xml_content)),
-            _ => Err(Error::Message(format!(
-                "Unknown message type: {}",
-                tag_name
-            ))),
+        match name.as_str() {
+            "getProperties" => Ok(Message::GetProperty(xml.to_string())),
+            "defProperty" => Ok(Message::DefProperty(xml.to_string())),
+            "setProperty" => Ok(Message::SetProperty(xml.to_string())),
+            "newProperty" => Ok(Message::NewProperty(xml.to_string())),
+            "defDevice" => Ok(Message::DefDevice(xml.to_string())),
+            "message" => Ok(Message::Message(xml.to_string())),
+            _ => Err(Error::Message(format!("Invalid message type: {}", name))),
         }
     }
 
-    /// Convert a Message to an XML string
+    /// Convert Message enum to XML string
     pub fn to_xml(&self) -> Result<String> {
         match self {
-            Message::DefDevice(xml)
-            | Message::DefProperty(xml)
-            | Message::SetProperty(xml)
-            | Message::GetProperty(xml)
-            | Message::NewProperty(xml)
-            | Message::DelProperty(xml)
-            | Message::Message(xml) => Ok(xml.clone()),
+            Message::GetProperty(xml) => Ok(xml.clone()),
+            Message::DefProperty(xml) => Ok(xml.clone()),
+            Message::SetProperty(xml) => Ok(xml.clone()),
+            Message::NewProperty(xml) => Ok(xml.clone()),
+            Message::DefDevice(xml) => Ok(xml.clone()),
+            Message::Message(xml) => Ok(xml.clone()),
         }
     }
 
-    /// Extract device name from XML message
+    /// Get device name from message
     pub fn get_device(&self) -> Result<String> {
         let xml = self.to_xml()?;
-        let (_, (_, attrs, _)) = parse_xml_tag(&xml)
-            .map_err(|e| Error::Message(format!("Failed to parse XML: {}", e)))?;
+        let (_, (_, attrs)) = parse_element_start(&xml).map_err(|e| Error::Message(e.to_string()))?;
 
         attrs
             .iter()
             .find(|attr| attr.name == "device")
             .map(|attr| attr.value.clone())
-            .ok_or_else(|| Error::Message("Device attribute not found".to_string()))
+            .ok_or_else(|| Error::Message("Missing device attribute".to_string()))
     }
 
-    /// Extract property name from XML message
+    /// Get property name from message
     pub fn get_property_name(&self) -> Result<String> {
         let xml = self.to_xml()?;
-        let (_, (_, attrs, _)) = parse_xml_tag(&xml)
-            .map_err(|e| Error::Message(format!("Failed to parse XML: {}", e)))?;
+        let (_, (_, attrs)) = parse_element_start(&xml).map_err(|e| Error::Message(e.to_string()))?;
 
         attrs
             .iter()
             .find(|attr| attr.name == "name")
             .map(|attr| attr.value.clone())
-            .ok_or_else(|| Error::Message("Name attribute not found".to_string()))
+            .ok_or_else(|| Error::Message("Missing name attribute".to_string()))
     }
 
-    /// Extract property value from XML message
+    /// Get property value from message
     pub fn get_property_value(&self) -> Result<PropertyValue> {
         let xml = self.to_xml()?;
-        println!("Getting property value from XML: {}", xml);
-        let (_, (tag_name, _attrs, content)) = parse_xml_tag(xml.trim())
-            .map_err(|e| Error::Message(format!("Failed to parse XML: {}", e)))?;
+        let (input, (_, _)) = parse_element_start(&xml).map_err(|e| Error::Message(e.to_string()))?;
 
-        // Only certain message types can have property values
-        match tag_name.as_str() {
-            "defProperty" | "setProperty" | "newProperty" => (),
-            _ => {
-                return Err(Error::Message(
-                    "Message type does not contain property value".to_string(),
-                ))
-            }
-        }
-
-        let content = content.ok_or_else(|| Error::Message("No content found".to_string()))?;
-        println!("Found content: {}", content);
-
-        // Parse the value tag inside the content
-        let (_, (value_type, attrs, value)) = parse_xml_tag(content.trim())
-            .map_err(|e| Error::Message(format!("Failed to parse value XML: {}", e)))?;
-
-        // Get the value, either from content or from empty tag
-        let value = match value {
-            Some(v) => v.trim().to_string(),
-            None => "".to_string(),
-        };
-        println!("Found value: {}", value);
+        // Parse value element
+        let (input, (value_type, attrs)) =
+            parse_element_start(input).map_err(|e| Error::Message(e.to_string()))?;
+        let (_, value) = parse_element_content(input).map_err(|e| Error::Message(e.to_string()))?;
 
         match value_type.as_str() {
             "oneText" => Ok(PropertyValue::Text(value)),
             "oneNumber" => Ok(PropertyValue::Number(
-                value
-                    .parse()
-                    .map_err(|_| Error::Message("Invalid number".to_string()))?,
-                Some(value_type.to_string()),
+                value.parse().map_err(|_| {
+                    Error::Message(format!("Invalid number value: {}", value))
+                })?,
+                None,
             )),
             "oneSwitch" => Ok(PropertyValue::Switch(value == "On")),
-            "oneLight" => {
-                Ok(PropertyValue::Light(value.parse().map_err(|_| {
-                    Error::Message("Invalid light state".to_string())
-                })?))
-            }
+            "oneLight" => Ok(PropertyValue::Light(value.parse()?)),
             "oneBLOB" => {
                 let format = attrs
                     .iter()
@@ -245,13 +169,38 @@ impl Message {
                     .decode(value.trim())
                     .map_err(|_| Error::Message("Invalid base64 data".to_string()))?;
                 let size = data.len();
-                Ok(PropertyValue::Blob { data, format, size })
+                Ok(PropertyValue::Blob {
+                    data,
+                    format,
+                    size,
+                })
             }
-            _ => Err(Error::Message(format!(
-                "Unknown property value type: {}",
-                value_type
-            ))),
+            _ => Err(Error::Message(format!("Invalid value type: {}", value_type))),
         }
+    }
+
+    /// Get property state from message
+    pub fn get_property_state(&self) -> Result<PropertyState> {
+        let xml = self.to_xml()?;
+        let (_, (_, attrs)) = parse_element_start(&xml).map_err(|e| Error::Message(e.to_string()))?;
+
+        attrs
+            .iter()
+            .find(|attr| attr.name == "state")
+            .map(|attr| attr.value.parse())
+            .unwrap_or_else(|| Ok(PropertyState::default()))
+    }
+
+    /// Get property permission from message
+    pub fn get_property_perm(&self) -> Result<PropertyPerm> {
+        let xml = self.to_xml()?;
+        let (_, (_, attrs)) = parse_element_start(&xml).map_err(|e| Error::Message(e.to_string()))?;
+
+        attrs
+            .iter()
+            .find(|attr| attr.name == "perm")
+            .map(|attr| attr.value.parse())
+            .unwrap_or_else(|| Ok(PropertyPerm::default()))
     }
 }
 
@@ -261,60 +210,26 @@ mod tests {
 
     #[test]
     fn test_message_parsing() {
-        let xml = "<getProperty device=\"test_device\" name=\"test_prop\"/>";
-        let msg = Message::from_xml(xml).unwrap();
-        assert!(matches!(msg, Message::GetProperty(_)));
-        assert_eq!(msg.get_device().unwrap(), "test_device");
-        assert_eq!(msg.get_property_name().unwrap(), "test_prop");
-    }
-
-    #[test]
-    fn test_property_value_parsing() {
-        let xml = "<newProperty device=\"CCD\" name=\"EXPOSURE\"><oneNumber>1.5</oneNumber></newProperty>";
-        let msg = Message::from_xml(xml).unwrap();
-
-        if let PropertyValue::Number(val, _) = msg.get_property_value().unwrap() {
-            assert_eq!(val, 1.5);
-        } else {
-            panic!("Wrong property value type");
-        }
-
-        let xml =
-            "<newProperty device=\"CCD\" name=\"POWER\"><oneSwitch>On</oneSwitch></newProperty>";
-        let msg = Message::from_xml(xml).unwrap();
-
-        if let PropertyValue::Switch(val) = msg.get_property_value().unwrap() {
-            assert!(val);
-        } else {
-            panic!("Wrong property value type");
-        }
-
-        // Test BLOB property
-        let data = vec![1, 2, 3, 4];
-        let xml = format!(
-            "<newProperty device=\"CCD\" name=\"IMAGE\"><oneBLOB format=\".fits\" size=\"4\">{}</oneBLOB></newProperty>",
-            STANDARD.encode(&data)
-        );
-        let msg = Message::from_xml(&xml).unwrap();
-
-        if let PropertyValue::Blob {
-            data: parsed_data,
-            format,
-            size,
-        } = msg.get_property_value().unwrap()
-        {
-            assert_eq!(parsed_data, data);
-            assert_eq!(format, ".fits");
-            assert_eq!(size, 4);
-        } else {
-            panic!("Wrong property value type");
-        }
+        let xml = "<getProperties version=\"1.7\"/>";
+        let message = Message::from_xml(xml).unwrap();
+        assert!(matches!(message, Message::GetProperty(_)));
     }
 
     #[test]
     fn test_message_serialization() {
-        let xml = "<getProperty device=\"test_device\" name=\"test_prop\"/>";
-        let msg = Message::from_xml(xml).unwrap();
-        assert_eq!(msg.to_xml().unwrap(), xml);
+        let xml = "<getProperties version=\"1.7\"/>";
+        let message = Message::GetProperty(xml.to_string());
+        assert_eq!(message.to_xml().unwrap(), xml);
+    }
+
+    #[test]
+    fn test_property_value_parsing() {
+        let xml = "<defProperty device=\"test\" name=\"test\"><oneText>test value</oneText></defProperty>";
+        let message = Message::DefProperty(xml.to_string());
+        let value = message.get_property_value().unwrap();
+        assert!(matches!(value, PropertyValue::Text(_)));
+        if let PropertyValue::Text(text) = value {
+            assert_eq!(text, "test value");
+        }
     }
 }

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,12 +1,12 @@
 use base64::engine::general_purpose::STANDARD;
 use base64::Engine;
+use nom::branch::alt;
 use nom::bytes::complete::{tag, take_while1};
 use nom::character::complete::{char, multispace0};
 use nom::multi::many0;
 use nom::sequence::delimited;
-use nom::branch::alt;
-use nom::Parser;
 use nom::IResult;
+use nom::Parser;
 
 use crate::error::{Error, Result};
 use crate::property::{PropertyPerm, PropertyState, PropertyValue};
@@ -118,7 +118,8 @@ impl Message {
     /// Get device name from message
     pub fn get_device(&self) -> Result<String> {
         let xml = self.to_xml()?;
-        let (_, (_, attrs)) = parse_element_start(&xml).map_err(|e| Error::Message(e.to_string()))?;
+        let (_, (_, attrs)) =
+            parse_element_start(&xml).map_err(|e| Error::Message(e.to_string()))?;
 
         attrs
             .iter()
@@ -130,7 +131,8 @@ impl Message {
     /// Get property name from message
     pub fn get_property_name(&self) -> Result<String> {
         let xml = self.to_xml()?;
-        let (_, (_, attrs)) = parse_element_start(&xml).map_err(|e| Error::Message(e.to_string()))?;
+        let (_, (_, attrs)) =
+            parse_element_start(&xml).map_err(|e| Error::Message(e.to_string()))?;
 
         attrs
             .iter()
@@ -142,7 +144,8 @@ impl Message {
     /// Get property value from message
     pub fn get_property_value(&self) -> Result<PropertyValue> {
         let xml = self.to_xml()?;
-        let (input, (_, _)) = parse_element_start(&xml).map_err(|e| Error::Message(e.to_string()))?;
+        let (input, (_, _)) =
+            parse_element_start(&xml).map_err(|e| Error::Message(e.to_string()))?;
 
         // Parse value element
         let (input, (value_type, attrs)) =
@@ -152,9 +155,9 @@ impl Message {
         match value_type.as_str() {
             "oneText" => Ok(PropertyValue::Text(value)),
             "oneNumber" => Ok(PropertyValue::Number(
-                value.parse().map_err(|_| {
-                    Error::Message(format!("Invalid number value: {}", value))
-                })?,
+                value
+                    .parse()
+                    .map_err(|_| Error::Message(format!("Invalid number value: {}", value)))?,
                 None,
             )),
             "oneSwitch" => Ok(PropertyValue::Switch(value == "On")),
@@ -169,20 +172,20 @@ impl Message {
                     .decode(value.trim())
                     .map_err(|_| Error::Message("Invalid base64 data".to_string()))?;
                 let size = data.len();
-                Ok(PropertyValue::Blob {
-                    data,
-                    format,
-                    size,
-                })
+                Ok(PropertyValue::Blob { data, format, size })
             }
-            _ => Err(Error::Message(format!("Invalid value type: {}", value_type))),
+            _ => Err(Error::Message(format!(
+                "Invalid value type: {}",
+                value_type
+            ))),
         }
     }
 
     /// Get property state from message
     pub fn get_property_state(&self) -> Result<PropertyState> {
         let xml = self.to_xml()?;
-        let (_, (_, attrs)) = parse_element_start(&xml).map_err(|e| Error::Message(e.to_string()))?;
+        let (_, (_, attrs)) =
+            parse_element_start(&xml).map_err(|e| Error::Message(e.to_string()))?;
 
         attrs
             .iter()
@@ -194,7 +197,8 @@ impl Message {
     /// Get property permission from message
     pub fn get_property_perm(&self) -> Result<PropertyPerm> {
         let xml = self.to_xml()?;
-        let (_, (_, attrs)) = parse_element_start(&xml).map_err(|e| Error::Message(e.to_string()))?;
+        let (_, (_, attrs)) =
+            parse_element_start(&xml).map_err(|e| Error::Message(e.to_string()))?;
 
         attrs
             .iter()


### PR DESCRIPTION
- Update nom dependency to version 8.0.0
- Fix parser function calls to use new parse() method
- Add support for self-closing tags
- Remove unused parse_element_end function